### PR TITLE
Add CMDSTAN_HOME and accessor.

### DIFF
--- a/src/Stan.jl
+++ b/src/Stan.jl
@@ -1,71 +1,82 @@
 module Stan
 
-# package code goes here
+using Mamba
 
-  using Mamba
+"""The directory which contains the executable `bin/stanc`. Inferred
+from `Main.CMDSTAN_HOME` or `ENV["CMDSTAN_HOME"]` when available. Use
+`set_CMDSTAN_HOME!` to modify."""
+CMDSTAN_HOME=""
 
-  include("stanmodel.jl")
-  include("stancode.jl")
-  include("utilities.jl")
-  
-  if !isdefined(Main, :CMDSTAN_HOME)
-    CMDSTAN_HOME = ""
-    try
-      CMDSTAN_HOME = ENV["CMDSTAN_HOME"]
-    catch e
-      println("Environment variable CMDSTAN_HOME not found.")
-      CMDSTAN_HOME = ""
+function __init__()
+    global CMDSTAN_HOME = if isdefined(Main, :CMDSTAN_HOME)
+        eval(Main, :CMDSTAN_HOME)
+    elseif haskey(ENV, "CMDSTAN_HOME")
+        ENV["CMDSTAN_HOME"]
+    else
+        warn("Environment variable CMDSTAN_HOME not found. Use set_CMDSTAN_HOME!.")
+        ""
     end
-  end
-  
-  if !isdefined(Main, :JULIA_SVG_BROWSER)
+end
+
+"""Set the path for `CMDSTAN`.
+    
+Example: `set_CMDSTAN_HOME!(homedir() * "/src/src/cmdstan-2.9.0/")`"""
+set_CMDSTAN_HOME!(path) = global CMDSTAN_HOME=path
+
+if !isdefined(Main, :JULIA_SVG_BROWSER)
     JULIA_SVG_BROWSER = ""
     try
-      JULIA_SVG_BROWSER = ENV["JULIA_SVG_BROWSER"]
+        JULIA_SVG_BROWSER = ENV["JULIA_SVG_BROWSER"]
     catch e
-      println("Environment variable JULIA_SVG_BROWSER not found.")
-      JULIA_SVG_BROWSER = ""
+        println("Environment variable JULIA_SVG_BROWSER not found.")
+        JULIA_SVG_BROWSER = ""
     end
-  end
-  
-  export
-  # From stancode.jl
-    stan,
-    stan_summary,
-    read_stanfit,
-    read_stanfit_samples,
-    CMDSTAN_HOME,
-    JULIA_SVG_BROWSER,
-  # From stanmodel.jl
-    Stanmodel,
-    Data,
-    RNG,
-    Output,
-  # From sampletype.jl
-    Sample,
-    Hmc,
-    diag_e,
-    unit_e,
-    dense_e,
-    Engine,
-    Nuts,
-    Static,
-    Metrics,
-    SampleAlgorithm,
-    Fixed_param,
-    Adapt,
-  # From optimizetype.jl
-    Optimize,
-    Lbfgs,
-    Bfgs,
-    Newton,
-  # From diagnosetype.jl
-    Diagnose,
-    Diagnostics,
-    Gradient,
-  # From variationaltype.jl
-    Variational,
-  # From cmdline.jl
-    cmdline
+end
+
+include("stanmodel.jl")
+include("stancode.jl")
+include("utilities.jl")
+
+export
+# from this file
+set_CMDSTAN_HOME!,
+# From stancode.jl
+stan,
+stan_summary,
+read_stanfit,
+read_stanfit_samples,
+CMDSTAN_HOME,
+JULIA_SVG_BROWSER,
+# From stanmodel.jl
+Stanmodel,
+Data,
+RNG,
+Output,
+# From sampletype.jl
+Sample,
+Hmc,
+diag_e,
+unit_e,
+dense_e,
+Engine,
+Nuts,
+Static,
+Metrics,
+SampleAlgorithm,
+Fixed_param,
+Adapt,
+# From optimizetype.jl
+Optimize,
+Lbfgs,
+Bfgs,
+Newton,
+# From diagnosetype.jl
+Diagnose,
+Diagnostics,
+Gradient,
+# From variationaltype.jl
+Variational,
+# From cmdline.jl
+cmdline
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,9 @@ using Base.Test
 
 println("Running tests for Stan-j0.4-v0.3.2:")
 
-code_tests = [
-  "test_utilities.jl",
-  "test_cmdtype.jl"
-]
+code_tests = ["test_env.jl",              
+              "test_utilities.jl",
+              "test_cmdtype.jl"]
 
 # Run execution_tests only if CmdStan is installed and CMDSTAN_HOME is set correctly.
 execution_tests = [
@@ -22,20 +21,20 @@ for my_test in code_tests
     include(my_test)
 end
 
-if isdefined(Main, :CMDSTAN_HOME) && length(CMDSTAN_HOME) > 0
-  println("CMDSTAN_HOME found! Try to run bernoulli.")
+if CMDSTAN_HOME != ""
+  println("CMDSTAN_HOME set. Try to run bernoulli.")
   try
     for my_test in execution_tests
         println("\n  * $(my_test) *")
         include(my_test)
     end
   catch e
-     println("CMDSTAN_HOME found, but CmdStan not installed properly.")
+     println("CMDSTAN_HOME initialized, but CmdStan not installed properly.")
      println(e)
      println("No simulation runs have been performed.")
   end 
 else
-  println("\n\nCMDSTAN_HOME not found. Skipping all tests that depend on CmdStan!\n")  
+  println("\n\nCMDSTAN_HOME not initialized. Skipping all tests that depend on CmdStan!\n")
 end
 
 println("\n")

--- a/test/test_env.jl
+++ b/test/test_env.jl
@@ -1,0 +1,8 @@
+## testing accessors to CMDSTAN_HOME
+let oldpath = Stan.CMDSTAN_HOME
+    newpath = Stan.CMDSTAN_HOME * "##test##"
+    set_CMDSTAN_HOME!(newpath)
+    @test Stan.CMDSTAN_HOME == newpath
+    set_CMDSTAN_HOME!(oldpath)
+    @test Stan.CMDSTAN_HOME == oldpath
+end


### PR DESCRIPTION
Fixes problems with inferring CMDSTAN_HOME and using it as a default
argument by introducing it into the scope of the module. Since this
cannot be modifed outside the module, also add an accessor. Add
__init__() which infers a value from Main or ENV when the module is
first loaded.

Cosmetic changes: warn instead of println, remove indentation inside
module (as recommended in Julia).