### PR TITLE
Fixed type checking for data that has type Dict{ASCIIString,Int64}.

### DIFF
--- a/Examples/Binomial/binomial.jl
+++ b/Examples/Binomial/binomial.jl
@@ -1,0 +1,62 @@
+## Binomial Example ####
+## Note: Adapted from the Rate_4 example in Bayesian Cognitive Modeling
+##  https://github.com/stan-dev/example-models/tree/master/Bayesian_Cognitive_Modeling
+
+using Mamba, Stan
+
+old = pwd()
+ProjDir = Pkg.dir("Stan", "Examples", "Binomial")
+cd(ProjDir)
+
+const binomialstanmodel = "
+// Inferring a Rate
+data {
+  int<lower=1> n;
+  int<lower=0> k;
+}
+parameters {
+  real<lower=0,upper=1> theta;
+  real<lower=0,upper=1> thetaprior;
+}
+model {
+  // Prior Distribution for Rate Theta
+  theta ~ beta(1, 1);
+  thetaprior ~ beta(1, 1);
+
+  // Observed Counts
+  k ~ binomial(n, theta);
+}
+generated quantities {
+  int<lower=0> postpredk;
+  int<lower=0> priorpredk;
+
+  postpredk <- binomial_rng(n, theta);
+  priorpredk <- binomial_rng(n, thetaprior);
+}
+"
+
+stanmodel = Stanmodel(name="binomial", model=binomialstanmodel)
+
+const binomialdata = [
+  Dict("n" => 10, "k" => 5)
+]
+
+sim1 = stan(stanmodel, binomialdata, ProjDir, diagnostics=false,
+            CmdStanDir=CMDSTAN_HOME)
+theta_sim = sim1[1:size(sim1,1), ["theta", "thetaprior"], :]
+predk_sim = sim1[1:size(sim1,1), ["postpredk", "priorpredk"], :]
+
+p = plot(theta_sim, [:trace, :mean, :density, :autocor], legend=false);
+draw(p, ncol=4, nrow=2, filename="$(stanmodel.name)-thetas", fmt=:svg)
+
+p = plot(predk_sim, [:bar], legend=false)
+draw(p, ncol=2, nrow=2, filename="$(stanmodel.name)-predictiv", fmt=:svg)
+
+if length(JULIA_SVG_BROWSER) > 0
+  @osx ? for fn in readdir()
+    match(r".*\.svg", fn) != nothing &&
+      run(`open -a $(JULIA_SVG_BROWSER) "$fn"`)
+  end : println()
+end
+
+cd(old)

--- a/src/stancode.jl
+++ b/src/stancode.jl
@@ -2,6 +2,15 @@
 # Basic definitions
 #
 
+function check_data_type(data)
+  if typeof(data) <: Array && length(data) > 0
+    if keytype(data[1]) == ASCIIString && valtype(data[1]) <: Any
+      return true
+    end
+  end
+  return false
+end
+
 function stan(
   model::Stanmodel, 
   data=Void, 
@@ -37,7 +46,7 @@ function stan(
     run(pipeline(`make $(tmpmodelname)`, stderr="$(tmpmodelname)_build.log"))
         
     cd(model.tmpdir)
-    if data != Void && isa(data, Array{Dict{ASCIIString, Any}, 1}) && length(data) > 0
+    if data != Void && check_data_type(data)
       if length(data) == model.nchains
         for i in 1:model.nchains
           if length(keys(data[i])) > 0
@@ -122,7 +131,7 @@ function stan(
   res
 end
 
-function update_R_file(file::ASCIIString, dct::Dict{ASCIIString, Any}; replaceNaNs::Bool=true)
+function update_R_file{T<:Any}(file::ASCIIString, dct::Dict{ASCIIString, T}; replaceNaNs::Bool=true)
   isfile(file) && rm(file)
   strmout = open(file, "w")
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ code_tests = ["test_env.jl",
 # Run execution_tests only if CmdStan is installed and CMDSTAN_HOME is set correctly.
 execution_tests = [
   "test_bernoulli.jl",
+  "test_binomial.jl",
   "test_binormal.jl",
   "test_schools8.jl",
   "test_dyes.jl",

--- a/test/test_binomial.jl
+++ b/test/test_binomial.jl
@@ -1,0 +1,12 @@
+old = pwd()
+ProjDir = Pkg.dir("Stan", "Examples", "Binomial")
+cd(ProjDir)
+println("Moving to directory: $(ProjDir)")
+
+cd(ProjDir)
+isdir("tmp") &&
+  rm("tmp", recursive=true);
+
+include(Pkg.dir(ProjDir, "binomial.jl"))
+
+cd(old)


### PR DESCRIPTION
First of all, thanks for creating this great package!

I was running examples from the book Bayesian Cognitive Modeling last night and noticed that when I used data with a type `Array{Dict{ASCIIString,Int64}, 1}` the type check on line 40 of stancode.jl was failing. This pull request is just a fix for that issue. I added a test that is the same code that was causing the error for me last night.