### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language:julia
 julia:
   - 0.4
+  - 0.5
+  - nightly

--- a/Examples/ARM/Ch03/Kid/kidscore.jl
+++ b/Examples/ARM/Ch03/Kid/kidscore.jl
@@ -2,9 +2,8 @@
 
 using Stan, Mamba
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "ARM", "Ch03", "Kid")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 const kid = "
 data {
@@ -227,4 +226,4 @@ draw(p, ncol=4, filename="$(stanmodel.name)-summaryplot", fmt=:pdf)
         end
       end : println()
 
-cd(old)
+end # cd

--- a/Examples/Bernoulli/bernoulli.jl
+++ b/Examples/Bernoulli/bernoulli.jl
@@ -2,9 +2,8 @@
 
 using Mamba, Stan
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 bernoullimodel = "
 data { 
@@ -97,4 +96,4 @@ if Pkg.installed("Mamba") > v"0.7.1"
 	      end : println()
 end
 
-cd(old)
+end # cd

--- a/Examples/Bernoulli/bernoulli_diagnose.jl
+++ b/Examples/Bernoulli/bernoulli_diagnose.jl
@@ -2,9 +2,8 @@
 
 using Stan
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 bernoulli = "
 data { 
@@ -32,4 +31,4 @@ stanmodel = Stanmodel(Diagnose(Gradient(epsilon=1e-6)), name="bernoulli", model=
 diags = stan(stanmodel, bernoullidata, ProjDir, CmdStanDir=CMDSTAN_HOME);
 diags[1]["diagnose"] |> display
 
-cd(old)
+end # cd

--- a/Examples/Bernoulli/bernoulli_optimize.jl
+++ b/Examples/Bernoulli/bernoulli_optimize.jl
@@ -2,9 +2,8 @@
 
 using Stan
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 bernoulli = "
 data { 
@@ -32,4 +31,4 @@ stanmodel = Stanmodel(Optimize(), name="bernoulli", model=bernoulli);
 optim = stan(stanmodel, bernoullidata, ProjDir, CmdStanDir=CMDSTAN_HOME);
 optim |> display
 
-cd(old)
+end # cd

--- a/Examples/Bernoulli/bernoulli_variational.jl
+++ b/Examples/Bernoulli/bernoulli_variational.jl
@@ -2,9 +2,8 @@
 
 using Mamba, Stan
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 bernoulli = "
 data { 
@@ -49,4 +48,4 @@ draw(p, ncol=1, nrow=4, filename="$(stanmodel.name)-variationalplot", fmt=:pdf)
         end
       end : println()
 
-cd(old)
+end # cd

--- a/Examples/Binomial/binomial.jl
+++ b/Examples/Binomial/binomial.jl
@@ -4,9 +4,8 @@
 
 using Mamba, Stan
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Binomial")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 const binomialstanmodel = "
 // Inferring a Rate
@@ -59,4 +58,4 @@ if length(JULIA_SVG_BROWSER) > 0
   end : println()
 end
 
-cd(old)
+end # cd

--- a/Examples/Binormal/binormal.jl
+++ b/Examples/Binormal/binormal.jl
@@ -2,9 +2,8 @@
 
 using Stan, Mamba
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Binormal")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 const binorm = "
 transformed data {
@@ -77,4 +76,4 @@ draw(p, ncol=4, filename="$(stanmodel.name)-summaryplot", fmt=:pdf)
       end : println()
 
 
-cd(old)
+end # cd

--- a/Examples/Dyes/dyes.jl
+++ b/Examples/Dyes/dyes.jl
@@ -2,9 +2,8 @@
 
 using Stan, Mamba
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Dyes")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 const dyes ="
 data {
@@ -111,4 +110,4 @@ draw(p, ncol=4, filename="$(stanmodel.name)-summaryplot", fmt=:pdf)
         end
       end : println()
 
-cd(old)
+end # cd

--- a/Examples/EightSchools/schools8.jl
+++ b/Examples/EightSchools/schools8.jl
@@ -2,9 +2,8 @@
 
 using Stan, Mamba
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "EightSchools")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 const eightschools ="
 data {
@@ -87,4 +86,4 @@ draw(p, nrow=4, ncol=4, filename="$(stanmodel.name)-summaryplot", fmt=:pdf)
         end
       end : println()
 
-cd(old)
+end # cd

--- a/Examples/ODE/ode.jl
+++ b/Examples/ODE/ode.jl
@@ -15,9 +15,8 @@
 
 using Mamba, Stan, Distributions
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "ODE")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 odemodel = "
 functions {
@@ -135,4 +134,4 @@ draw(p, nrow=4, ncol=4, filename="$(stanmodel.name)-sigmaplot", fmt=:pdf)
         end
       end : println()
 
-cd(old)
+end # cd

--- a/test/test_bernoulli.jl
+++ b/test/test_bernoulli.jl
@@ -1,34 +1,33 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Bernoulli")
+cd(ProjDir) do
 println("Moving to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "bernoulli.jl"))
+include(joinpath(ProjDir, "bernoulli.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "bernoulli_optimize.jl"))
+include(joinpath(ProjDir, "bernoulli_optimize.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "bernoulli_diagnose.jl"))
+include(joinpath(ProjDir, "bernoulli_diagnose.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "bernoulli_variational.jl"))
+include(joinpath(ProjDir, "bernoulli_variational.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old)
+end # cd

--- a/test/test_binomial.jl
+++ b/test/test_binomial.jl
@@ -1,17 +1,16 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Binomial")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Binomial")
+cd(ProjDir) do
 println("Moving to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "binomial.jl"))
+include(joinpath(ProjDir, "binomial.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
 
-cd(old)
+end # cd

--- a/test/test_binormal.jl
+++ b/test/test_binormal.jl
@@ -1,16 +1,15 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Binormal")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Binormal")
+cd(ProjDir) do
 println("Moving to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "binormal.jl"))
+include(joinpath(ProjDir, "binormal.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old);
+end # cd

--- a/test/test_cmdtype.jl
+++ b/test/test_cmdtype.jl
@@ -1,9 +1,8 @@
 using Stan
 using Base.Test
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "test")
-cd(ProjDir)
+ProjDir = dirname(@__FILE__)
+cd(ProjDir) do
 
 bernoulli = "
 data { 
@@ -79,4 +78,4 @@ cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old)
+end # cd

--- a/test/test_dyes.jl
+++ b/test/test_dyes.jl
@@ -1,16 +1,15 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Dyes")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Dyes")
+cd(ProjDir) do
 println("Moving to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "dyes.jl"))
+include(joinpath(ProjDir, "dyes.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old);
+end # cd

--- a/test/test_kidscore.jl
+++ b/test/test_kidscore.jl
@@ -1,16 +1,15 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "ARM", "Ch03", "Kid")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "ARM", "Ch03", "Kid")
+cd(ProjDir) do
 println("Moving to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "kidscore.jl"))
+include(joinpath(ProjDir, "kidscore.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old);
+end # cd

--- a/test/test_schools8.jl
+++ b/test/test_schools8.jl
@@ -1,16 +1,15 @@
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "EightSchools")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "EightSchools")
+cd(ProjDir) do
 println("Switched to directory: $(ProjDir)")
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-include(Pkg.dir(ProjDir, "schools8.jl"))
+include(joinpath(ProjDir, "schools8.jl"))
 
 cd(ProjDir)
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
-cd(old);
+end # cd

--- a/test/test_win.jl
+++ b/test/test_win.jl
@@ -11,15 +11,14 @@ end
 
 # Go to the Stan.jl package directory
 
-old = pwd()
-ProjDir = Pkg.dir("Stan", "Examples", "Bernoulli")
-cd(ProjDir)
+ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Bernoulli")
+cd(ProjDir) do
 
 isdir("tmp") &&
   rm("tmp", recursive=true);
 
 try
-  include(Pkg.dir(ProjDir, "bernoulli.jl"))
+  include(joinpath(ProjDir, "bernoulli.jl"))
 catch e
   println(e)
 end
@@ -31,6 +30,5 @@ println()
 println(stanmodel.command)
 println()
 
-cd(old)
-
+end # cd
 


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done.
(Is this enabled? You should turn it on at https://travis-ci.org/goedman/Stan.jl)

There are a few more instances of Pkg.dir that can
probably be replaced with joinpath.

Use `cd(folder) do ... end` blocks instead of having to save the previous location and go back at the end of scripts.