### PR TITLE
Pull request/1f4bdfee

### DIFF
--- a/src/stancode.jl
+++ b/src/stancode.jl
@@ -132,6 +132,49 @@ function stan(
 end
 
 function update_R_file{T<:Any}(file::String, dct::Dict{String, T}; replaceNaNs::Bool=true)
+    isfile(file) && rm(file)
+    strmout = open(file, "w")
+  
+    for entry in dct
+        line = Any["\"", entry[1], "\"", " <- "]
+        val = entry[2]
+        if length(val)==1 && length(size(val))==0
+            # Scalar
+            push!(line,val)
+        elseif length(val)==1 && length(size(val))==1
+            # Single element vector
+            push!(line,val[1])
+        elseif length(val)>1 && length(size(val))==1
+            # Vector
+            push!(line, "structure(c(")
+            for i in 1:length(val)
+                push!(line,val[i])
+                if i < length(val)
+                    push!(line,", ")
+                end
+            end
+            push!(line,"), .Dim=c(")
+            push!(line,length(val))
+            push!(line,"))")
+        elseif length(val)>1 && length(size(val))>1
+            # Array             
+            push!(line,"structure(c(" )
+            for i in 1:length(val)
+                push!(line,val[i])              
+                if i < length(val)
+                    push!(line,", ")
+                end
+            end
+            push!(line, "), .Dim=c")
+            push!(line, size(val))
+            push!(line, ")")
+        end
+        println(strmout, line...)
+    end
+    close(strmout)
+end
+
+function update_R_file_old{T<:Any}(file::String, dct::Dict{String, T}; replaceNaNs::Bool=true)
   isfile(file) && rm(file)
   strmout = open(file, "w")
   
@@ -487,3 +530,4 @@ function cmdline(m)
   end
   cmd
 end
+

--- a/src/stancode.jl
+++ b/src/stancode.jl
@@ -132,46 +132,46 @@ function stan(
 end
 
 function update_R_file{T<:Any}(file::String, dct::Dict{String, T})
-    isfile(file) && rm(file)
-    strmout = open(file, "w")
+  isfile(file) && rm(file)
+  strmout = open(file, "w")
   
-    for entry in dct
-        line = Any["\"", entry[1], "\"", " <- "]
-        val = entry[2]
-        if length(val)==1 && length(size(val))==0
-            # Scalar
-            push!(line,val)
-        elseif length(val)==1 && length(size(val))==1
-            # Single element vector
-            push!(line,val[1])
-        elseif length(val)>1 && length(size(val))==1
-            # Vector
-            push!(line, "structure(c(")
-            for i in 1:length(val)
-                push!(line,val[i])
-                if i < length(val)
-                    push!(line,", ")
-                end
-            end
-            push!(line,"), .Dim=c(")
-            push!(line,length(val))
-            push!(line,"))")
-        elseif length(val)>1 && length(size(val))>1
-            # Array             
-            push!(line,"structure(c(" )
-            for i in 1:length(val)
-                push!(line,val[i])              
-                if i < length(val)
-                    push!(line,", ")
-                end
-            end
-            push!(line, "), .Dim=c")
-            push!(line, size(val))
-            push!(line, ")")
+  for entry in dct
+    line = Any["\"", entry[1], "\"", " <- "]
+    val = entry[2]
+    if length(val)==1 && length(size(val))==0
+      # Scalar
+      push!(line,val)
+    elseif length(val)==1 && length(size(val))==1
+      # Single element vector
+      push!(line,val[1])
+    elseif length(val)>1 && length(size(val))==1
+      # Vector
+      push!(line, "structure(c(")
+      for i in 1:length(val)
+        push!(line,val[i])
+        if i < length(val)
+          push!(line,", ")
         end
-        println(strmout, line...)
+      end
+      push!(line,"), .Dim=c(")
+      push!(line,length(val))
+      push!(line,"))")
+    elseif length(val)>1 && length(size(val))>1
+      # Array             
+      push!(line,"structure(c(" )
+      for i in 1:length(val)
+        push!(line,val[i])              
+        if i < length(val)
+          push!(line,", ")
+        end
+      end
+      push!(line, "), .Dim=c")
+      push!(line, size(val))
+      push!(line, ")")
     end
-    close(strmout)
+    println(strmout, line...)
+  end
+  close(strmout)
 end
 
 function update_R_file_old{T<:Any}(file::String, dct::Dict{String, T})

--- a/src/stancode.jl
+++ b/src/stancode.jl
@@ -131,7 +131,7 @@ function stan(
   res
 end
 
-function update_R_file{T<:Any}(file::String, dct::Dict{String, T}; replaceNaNs::Bool=true)
+function update_R_file{T<:Any}(file::String, dct::Dict{String, T})
     isfile(file) && rm(file)
     strmout = open(file, "w")
   
@@ -174,7 +174,7 @@ function update_R_file{T<:Any}(file::String, dct::Dict{String, T}; replaceNaNs::
     close(strmout)
 end
 
-function update_R_file_old{T<:Any}(file::String, dct::Dict{String, T}; replaceNaNs::Bool=true)
+function update_R_file_old{T<:Any}(file::String, dct::Dict{String, T})
   isfile(file) && rm(file)
   strmout = open(file, "w")
   


### PR DESCRIPTION
Significantly improves update_R_file, old implementation is kept in update_R_file_old. I also removed an unused default parameter in update_R_file. The following comparison is done on a macbook pro.

For small data the difference is negligleble:

```julia
N = 10
data = Dict("Scalar" => rand(),
            "Single_element_vector" => [rand()], 
            "Vector" => rand(N),
            "Array" => rand(N,3))

@time Stan.update_R_file("testdata0", data)
@time Stan.update_R_file_old("testdata1", data)
```

gives

```
0.000550 seconds (200 allocations: 9.859 KB)
0.000582 seconds (629 allocations: 93.781 KB)
```

But on large data, the speed up is significant.

```julia
N = 10000
data = Dict("Scalar" => rand(),
            "Single_element_vector" => [rand()], 
            "Vector" => rand(N),
            "Array" => rand(N,3))

@time Stan.update_R_file("testdata0", data)
@time Stan.update_R_file_old("testdata1", data)
```

gives

```
 0.033156 seconds (238.07 k allocations: 8.188 MB)
 52.889273 seconds (638.21 k allocations: 56.671 GB, 41.81% gc time)
```

i.e. More than 1000 x speed up.

Best
Jon
